### PR TITLE
changes to blacklist to improve real-world usability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+Defender.log

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Note that the function does not separate by word and may capture other words tha
 
 As suggested by the previous note, regular expressions are allowed in the blacklist. However, they have not been thoroughly tested yet and may break things.
 
+The blacklist.txt hits on any string containing given words. So e.g. ass in blacklist blocks also glasses, biomass or assault.
+To hit only word surrounded by non-word characters, use ([^\w+]|^)word2block([^\w+]|$).
+
 ### replacements.ini
 To configure replacement values, please enter *find:replace* pairs in the replacements.ini file. For example, the replacement pair "blue:red" will replace all instances of the word "blue" with the word "red". As mentioend in the previous section, this may lead to overzealous replacements. This may be solved in a similar way by adding the regular expression tag as noted above. 
 ## ToDo

--- a/README.md
+++ b/README.md
@@ -26,14 +26,16 @@ To install this extension, follow these steps:
 
 ## Configuration
 ### Blacklist.txt
-The blacklist.txt file is easy to configure. On each new line, enter one term or phrase you would like to blackist. There is no need to separate terms with a comma or enclose them in quotes. Please be sure to delete the default sample text before adding your list.
+The blacklist.txt file is easy to configure. On each new line, enter one term or phrase you would like to blackist. 
+There is no need to separate terms with a comma or enclose them in quotes. Please be sure to delete the default sample text before adding your list.
 
-Note that the function does not separate by word and may capture other words that contain your blacklisted term. For example a blacklisted term of "red" will also block "redmond". If you beleive this is happening, double check your defender.log file. To remedy this, add the expression "(\s|\,|\_|\-|$)" without the quotes to the end of your term. Ex: "red(\s|\,|\_|\-|$)". You do not need to add this by default to all terms.
+Note that the function does not separate by word and may capture other words that contain your blacklisted term. 
+For example a blacklisted term of "red" will also block "redmond" or "predict". If you believe this is happening, 
+double-check your defender.log file. To remedy this, wrap the expression into "([^\w+]|^)your expression([^\w+]|$)" 
+without the quotes. Ex: "([^\w+]|^)red([^\w+]|$)". You do not need to add this by default to all terms.
 
-As suggested by the previous note, regular expressions are allowed in the blacklist. However, they have not been thoroughly tested yet and may break things.
-
-The blacklist.txt hits on any string containing given words. So e.g. ass in blacklist blocks also glasses, biomass or assault.
-To hit only word surrounded by non-word characters, use ([^\w+]|^)word2block([^\w+]|$).
+As suggested by the previous note, regular expressions are allowed in the blacklist. 
+However, they have not been thoroughly tested yet and may break things.
 
 ### replacements.ini
 To configure replacement values, please enter *find:replace* pairs in the replacements.ini file. For example, the replacement pair "blue:red" will replace all instances of the word "blue" with the word "red". As mentioend in the previous section, this may lead to overzealous replacements. This may be solved in a similar way by adding the regular expression tag as noted above. 

--- a/blacklist.txt
+++ b/blacklist.txt
@@ -9,3 +9,4 @@ or phrase
 on
 each
 line
+([^\w+]|^)not partial hit([^\w+]|$)

--- a/scripts/DiffusionDefender.py
+++ b/scripts/DiffusionDefender.py
@@ -38,7 +38,9 @@ def find_and_replace(string_to_review, replacements):
 def ReviewBlacklist(StringToReview,blacklist): #This works
     result = False
     for words in blacklist:
-        if re.search(words,StringToReview.lower()) != None:
+        m = re.search(words,StringToReview.lower())
+        if m != None:
+            log.info(f'BLACKLIST WORD HIT: {m.group(0)}')
             result = True
     return result
 

--- a/scripts/DiffusionDefender.py
+++ b/scripts/DiffusionDefender.py
@@ -37,12 +37,13 @@ def find_and_replace(string_to_review, replacements):
 
 def ReviewBlacklist(StringToReview,blacklist): #This works
     result = False
+    hit_words = []
     for words in blacklist:
         m = re.search(words,StringToReview.lower())
-        if m != None:
-            log.info(f'BLACKLIST WORD HIT: {m.group(0)}')
+        if m is not None:
+            hit_words.append(m.group(0))
             result = True
-    return result
+    return result, hit_words
 
 def LoadConfig(configonly=False):
     #Load Options
@@ -106,7 +107,10 @@ class Script(scripts.Script):
 
         try:
             if config_options['useblacklist']:
-                BlacklistTripped = ReviewBlacklist(prompt,blacklist)
+                BlacklistTripped, HitWords = ReviewBlacklist(prompt,blacklist)
+                if config_options['addtolog'] and len(HitWords) > 0:
+                    log.info(f'BLACKLIST WORDS HIT: {",".join(HitWords)}')
+
         except Exception as ex:
             log.error(f'Unable to reference prompt against blacklist: {type(ex)}')
 


### PR DESCRIPTION
Hi, I have used this extension on AnimeFest 2023 where over thousand visitors used stable diffusion with this extension.
Thanks for it!
Here are some additions I needed to add to improve the usability.
When the blacklist is long, it's useful to see which word hit. Especially when working with regexes.
Also I added example with regex that I have used and served well to block problematic words, but not words that contain them as their part. For example, the regex in readme blocks ass, but not assault, nor glasses, nor biomass.